### PR TITLE
feat: Add mock GraphQL server for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbopack",
+		"dev": "STAGE=local npm run dev:with-mock",
+		"dev:with-mock": "concurrently \"npm run mock:server\" \"next dev --turbopack\"",
+		"dev:prod": "next dev --turbopack",
+		"mock:server": "tsx src/mock/server-standalone.ts",
 		"build": "next build",
 		"start": "next start",
 		"lint": "biome lint --write ./src/**/*",
@@ -15,6 +18,7 @@
 		"@apollo/client-integration-nextjs": "^0.12.2",
 		"@vercel/otel": "^1.11.0",
 		"graphql": "^16.11.0",
+		"graphql-yoga": "^5.0.0",
 		"next": "15.3.1",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
@@ -25,8 +29,10 @@
 		"@types/node": "^20",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
+		"concurrently": "^8.2.2",
 		"lefthook": "^1.11.11",
 		"tailwindcss": "^4",
+		"tsx": "^4.7.0",
 		"typescript": "^5"
 	}
 }

--- a/src/app/ApolloWrapper.tsx
+++ b/src/app/ApolloWrapper.tsx
@@ -6,10 +6,11 @@ import {
 	ApolloClient,
 	InMemoryCache,
 } from "@apollo/client-integration-nextjs";
+import { getGraphQLEndpoint } from "../config/graphql";
 
 function makeClient() {
 	const httpLink = new HttpLink({
-		uri: "http://localhost:4000/graphql",
+		uri: getGraphQLEndpoint(),
 	});
 
 	return new ApolloClient({

--- a/src/config/graphql.ts
+++ b/src/config/graphql.ts
@@ -1,0 +1,9 @@
+export function getGraphQLEndpoint(): string {
+  const stage = process.env.STAGE || 'development';
+  
+  if (stage === 'local') {
+    return 'http://localhost:4001/graphql';
+  }
+  
+  return 'http://localhost:4000/graphql';
+}

--- a/src/libs/apolloClient.ts
+++ b/src/libs/apolloClient.ts
@@ -4,11 +4,12 @@ import {
 	InMemoryCache,
 	ApolloClient,
 } from "@apollo/client-integration-nextjs";
+import { getGraphQLEndpoint } from "../config/graphql";
 
 export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
 	const client = new ApolloClient({
 		link: new HttpLink({
-			uri: "http://localhost:4000/graphql",
+			uri: getGraphQLEndpoint(),
 		}),
 		cache: new InMemoryCache(),
 	});

--- a/src/mock/server-standalone.ts
+++ b/src/mock/server-standalone.ts
@@ -1,0 +1,8 @@
+import { startMockServer } from './server';
+
+startMockServer(4001).then(() => {
+  console.log('Mock server is running');
+}).catch((error) => {
+  console.error('Failed to start mock server:', error);
+  process.exit(1);
+});

--- a/src/mock/server.ts
+++ b/src/mock/server.ts
@@ -1,0 +1,140 @@
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+
+let todos = [
+  {
+    id: "1",
+    text: "Learn GraphQL",
+    completed: false,
+    owner: { id: "user1", name: "Alice" },
+  },
+  {
+    id: "2", 
+    text: "Build Todo App",
+    completed: true,
+    owner: { id: "user1", name: "Alice" },
+  },
+  {
+    id: "3",
+    text: "Deploy to Production", 
+    completed: false,
+    owner: { id: "user2", name: "Bob" },
+  },
+];
+
+const typeDefs = `
+  type Owner {
+    id: ID!
+    name: String!
+  }
+
+  type Todo {
+    id: ID!
+    text: String!
+    completed: Boolean!
+    owner: Owner!
+  }
+
+  type AddTodoResponse {
+    success: Boolean!
+    message: String!
+    todo: Todo
+  }
+
+  type UpdateTodoResponse {
+    success: Boolean!
+    message: String!
+    todo: Todo
+  }
+
+  type DeleteTodoResponse {
+    success: Boolean!
+    message: String!
+  }
+
+  type Query {
+    todos: [Todo!]!
+  }
+
+  type Mutation {
+    addTodo(text: String!): AddTodoResponse!
+    updateTodoStatus(id: ID!, completed: Boolean!): UpdateTodoResponse!
+    deleteTodo(id: ID!): DeleteTodoResponse!
+  }
+`;
+
+const resolvers = {
+  Query: {
+    todos: () => todos,
+  },
+  Mutation: {
+    addTodo: (_: any, { text }: { text: string }) => {
+      const newTodo = {
+        id: String(Date.now()),
+        text,
+        completed: false,
+        owner: { id: "user1", name: "Alice" },
+      };
+      todos.push(newTodo);
+      return {
+        success: true,
+        message: "Todo added successfully",
+        todo: newTodo,
+      };
+    },
+    updateTodoStatus: (_: any, { id, completed }: { id: string; completed: boolean }) => {
+      const todo = todos.find(t => t.id === id);
+      if (!todo) {
+        return {
+          success: false,
+          message: "Todo not found",
+          todo: null,
+        };
+      }
+      todo.completed = completed;
+      return {
+        success: true,
+        message: "Todo updated successfully",
+        todo,
+      };
+    },
+    deleteTodo: (_: any, { id }: { id: string }) => {
+      const index = todos.findIndex(t => t.id === id);
+      if (index === -1) {
+        return {
+          success: false,
+          message: "Todo not found",
+        };
+      }
+      todos.splice(index, 1);
+      return {
+        success: true,
+        message: "Todo deleted successfully",
+      };
+    },
+  },
+};
+
+const yoga = createYoga({
+  typeDefs,
+  resolvers,
+  cors: {
+    origin: ['http://localhost:3000'],
+    credentials: true,
+  },
+});
+
+const server = createServer(yoga);
+
+export function startMockServer(port = 4001) {
+  return new Promise<void>((resolve) => {
+    server.listen(port, () => {
+      console.log(`🚀 Mock GraphQL server ready at http://localhost:${port}/graphql`);
+      resolve();
+    });
+  });
+}
+
+export function stopMockServer() {
+  server.close();
+}


### PR DESCRIPTION
GraphQLバックエンドにアクセスしているところを、`npm run dev`で起動している場合はmockサーバを自前で用意して、そこにアクセスするようにする

## 変更内容

- 環境変数`STAGE`によるGraphQLエンドポイント切り替え機能
- GraphQL Yogaを使用したモックサーバーの実装
- Apollo Clientの設定を環境に応じて切り替え
- `npm run dev`はSTAGE=localでモックサーバーと同時起動

## 使用方法

```bash
# モックサーバー付きで開発（STAGE=local）
npm run dev

# 通常の開発環境（実際のバックエンドに接続）
npm run dev:prod
```

Closes #2

Generated with [Claude Code](https://claude.ai/code)